### PR TITLE
feat(seo): add robots.txt and sitemap generation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,10 @@
 import { defineConfig } from "astro/config";
 import tailwind from "@astrojs/tailwind";
+import sitemap from "@astrojs/sitemap";
 import compress from "@playform/compress";
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [tailwind(), compress({ Image: false })],
+  site: "https://aztecahome.com",
+  integrations: [tailwind(), sitemap(), compress({ Image: false })],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "astro": "^4.11.3"
       },
       "devDependencies": {
+        "@astrojs/sitemap": "^3.2.1",
         "@astrojs/tailwind": "^5.1.0",
         "@playform/compress": "0.0.13",
         "astro-eleventy-img": "^0.6.2",
@@ -417,6 +418,18 @@
       },
       "engines": {
         "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.2.1.tgz",
+      "integrity": "sha512-uxMfO8f7pALq0ADL6Lk68UV6dNYjJ2xGUzyjjVj60JLBs5a6smtlkBYv3tQ0DzoqwS7c9n4FUx5lgv0yPo/fgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^8.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@astrojs/tailwind": {
@@ -2664,6 +2677,16 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
       "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
       "dev": true
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/sharp": {
       "version": "0.31.1",
@@ -11752,6 +11775,16 @@
         "suf-log": "^2.5.3"
       }
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -11974,6 +12007,33 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
+    "node_modules/sitemap": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.3.tgz",
+      "integrity": "sha512-9Ew1tR2WYw8RGE2XLy7GjkusvYXy8Rg6y8TYuBuQMfIEdGcWoJpY2Wr5DzsEiL/TKCw56+YKTCCUHglorEYK+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^17.0.5",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/slash": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
@@ -12038,6 +12098,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "astro": "^4.11.3"
   },
   "devDependencies": {
+    "@astrojs/sitemap": "^3.2.1",
     "@astrojs/tailwind": "^5.1.0",
     "@playform/compress": "0.0.13",
     "astro-eleventy-img": "^0.6.2",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://aztecahome.com/sitemap-index.xml


### PR DESCRIPTION
## Summary
- Add `@astrojs/sitemap@3.2.1` integration to auto-generate `sitemap-index.xml` + `sitemap-0.xml` at build time (pinned to 3.2.x because 3.7.x requires Astro 5's `astro:routes:resolved` hook)
- Set `site: "https://aztecahome.com"` in `astro.config.mjs` (required by the sitemap integration)
- Add static `public/robots.txt` allowing all crawlers and pointing at the generated sitemap for Google Search Console submission

## Test plan
- [x] `npm run build` succeeds
- [x] `dist/sitemap-index.xml` and `dist/sitemap-0.xml` are generated and contain all 21 pages
- [x] `dist/robots.txt` is published with correct sitemap URL
- [ ] After deploy, verify `https://aztecahome.com/robots.txt` and `https://aztecahome.com/sitemap-index.xml` resolve
- [ ] Submit `https://aztecahome.com/sitemap-index.xml` in Google Search Console