### PR TITLE
feat(seo): add JSON-LD structured data across the site

### DIFF
--- a/src/components/JsonLd.astro
+++ b/src/components/JsonLd.astro
@@ -1,0 +1,15 @@
+---
+interface Props {
+  data: Record<string, unknown> | Record<string, unknown>[];
+}
+
+const { data } = Astro.props;
+const graph = Array.isArray(data) ? data : [data];
+const payload = JSON.stringify({
+  "@context": "https://schema.org",
+  "@graph": graph,
+});
+const safe = payload.replace(/</g, "\\u003c");
+---
+
+<script type="application/ld+json" is:inline set:html={safe} />

--- a/src/layouts/Bug.astro
+++ b/src/layouts/Bug.astro
@@ -3,6 +3,7 @@
 import type { MarkdownLayoutProps } from "astro";
 import Layout from "./Layout.astro";
 import Banner from "../components/ui/Banner.astro";
+import { service, breadcrumb, SITE_URL } from "../lib/business";
 type Props = MarkdownLayoutProps<{
   // Define frontmatter props here
   title: string;
@@ -15,9 +16,24 @@ type Props = MarkdownLayoutProps<{
 
 const { frontmatter, compiledContent } = Astro.props;
 import "./Bug.css";
+
+const pageUrl = new URL(Astro.url.pathname, SITE_URL).href;
+const svc = service({
+  name: frontmatter.title,
+  url: pageUrl,
+  serviceType: `${frontmatter.bug} Control`,
+  description: `Professional ${frontmatter.bug.toLowerCase()} control and mitigation in Phoenix, AZ.`,
+  image: `${SITE_URL}${frontmatter.image}`,
+});
+
+const crumbs = breadcrumb([
+  { name: "Home", url: `${SITE_URL}/` },
+  { name: "Pest Control", url: `${SITE_URL}/pest-control/` },
+  { name: frontmatter.bug, url: pageUrl },
+]);
 ---
 
-<Layout title={frontmatter.title}>
+<Layout title={frontmatter.title} jsonLd={[svc, crumbs]}>
   <div class="container mx-auto mt-14">
     <div class="mx-4 flex items-center justify-between gap-4">
       <div class="rounded bg-army-100 p-4 font-bold">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,13 +1,18 @@
 ---
 import Footer from "../components/Footer.astro";
 import Header from "../components/Header.astro";
+import JsonLd from "../components/JsonLd.astro";
+import { business } from "../lib/business";
 // import { ViewTransitions } from "astro:transitions";
 
 export interface Props {
   title: string;
+  jsonLd?: Record<string, unknown> | Record<string, unknown>[];
 }
 
-const { title } = Astro.props;
+const { title, jsonLd } = Astro.props;
+const extras = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
+const graph = [business, ...extras];
 ---
 
 <!doctype html>
@@ -62,6 +67,7 @@ const { title } = Astro.props;
     />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
+    <JsonLd data={graph} />
     <!-- <ViewTransitions /> -->
   </head>
   <body class="bg-army-50">

--- a/src/lib/business.ts
+++ b/src/lib/business.ts
@@ -1,0 +1,109 @@
+export const SITE_URL = "https://aztecahome.com";
+export const BUSINESS_ID = `${SITE_URL}/#business`;
+export const WEBSITE_ID = `${SITE_URL}/#website`;
+
+export const business = {
+  "@type": ["LocalBusiness", "HomeAndConstructionBusiness"],
+  "@id": BUSINESS_ID,
+  name: "AZTECA Home Services",
+  url: SITE_URL,
+  telephone: "+1-602-926-2021",
+  image: `${SITE_URL}/favicon.svg`,
+  logo: `${SITE_URL}/favicon.svg`,
+  description:
+    "Pest control, pool, and landscape services in the Phoenix, AZ valley.",
+  address: {
+    "@type": "PostalAddress",
+    streetAddress: "3655 W Anthem Way A-109 #342",
+    addressLocality: "Phoenix",
+    addressRegion: "AZ",
+    postalCode: "85086",
+    addressCountry: "US",
+  },
+  areaServed: [
+    { "@type": "City", name: "Phoenix" },
+    { "@type": "AdministrativeArea", name: "Maricopa County" },
+  ],
+  hasOfferCatalog: {
+    "@type": "OfferCatalog",
+    name: "Home Services",
+    itemListElement: [
+      {
+        "@type": "Offer",
+        itemOffered: {
+          "@type": "Service",
+          name: "Pest Control",
+          url: `${SITE_URL}/pest-control/`,
+        },
+      },
+      {
+        "@type": "Offer",
+        itemOffered: {
+          "@type": "Service",
+          name: "Landscaping",
+          url: `${SITE_URL}/landscaping/`,
+        },
+      },
+      {
+        "@type": "Offer",
+        itemOffered: {
+          "@type": "Service",
+          name: "Pool Services",
+          url: `${SITE_URL}/pools/`,
+        },
+      },
+    ],
+  },
+};
+
+export const website = {
+  "@type": "WebSite",
+  "@id": WEBSITE_ID,
+  url: SITE_URL,
+  name: "AZTECA Home Services",
+  publisher: { "@id": BUSINESS_ID },
+};
+
+type BreadcrumbItem = { name: string; url: string };
+
+export function breadcrumb(items: BreadcrumbItem[]) {
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}
+
+type ServiceArgs = {
+  name: string;
+  url: string;
+  description?: string;
+  serviceType?: string;
+  image?: string;
+};
+
+export function service({
+  name,
+  url,
+  description,
+  serviceType,
+  image,
+}: ServiceArgs) {
+  return {
+    "@type": "Service",
+    name,
+    url,
+    ...(description && { description }),
+    ...(serviceType && { serviceType }),
+    ...(image && { image }),
+    provider: { "@id": BUSINESS_ID },
+    areaServed: [
+      { "@type": "City", name: "Phoenix" },
+      { "@type": "AdministrativeArea", name: "Maricopa County" },
+    ],
+  };
+}

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,8 +1,21 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import { breadcrumb, SITE_URL, BUSINESS_ID } from "../lib/business";
+
+const contactPage = {
+  "@type": "ContactPage",
+  url: `${SITE_URL}/contact/`,
+  name: "Contact AZTECA Home Services",
+  about: { "@id": BUSINESS_ID },
+};
+
+const crumbs = breadcrumb([
+  { name: "Home", url: `${SITE_URL}/` },
+  { name: "Contact", url: `${SITE_URL}/contact/` },
+]);
 ---
 
-<Layout title="Contact Us">
+<Layout title="Contact Us" jsonLd={[contactPage, crumbs]}>
   <main class="container my-12 mx-auto grid grid-cols-12">
     <section
       class="col-span-12 m-4 flex flex-col gap-4 bg-[url('/general/aztecaCalendarOutline.svg')] bg-contain bg-right-top bg-no-repeat text-xl sm:col-span-5"
@@ -78,7 +91,10 @@ import Layout from "../layouts/Layout.astro";
           Please fill out this form to make an online request for an estimate.
         </p>
         <p class="text-md text-army-700 mt-2">
-          <em>Please note that we request up to 48hr to get back to you about your estimate request.</em>
+          <em
+            >Please note that we request up to 48hr to get back to you about
+            your estimate request.</em
+          >
         </p>
       </div>
       <div

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,14 +1,14 @@
 ---
-import './index.css';
+import "./index.css";
 import Layout from "../layouts/Layout.astro";
 import ButtonLink from "../components/ui/ButtonLink.astro";
 import Banner from "../components/ui/Banner.astro";
 import MainImage from "../assets/landscape/general2.webp";
 import BlurryImage from "../components/ui/BlurryImage.astro";
-
+import { website } from "../lib/business";
 ---
 
-<Layout title="AZTECA Home Services">
+<Layout title="AZTECA Home Services" jsonLd={website}>
   <main>
     <section
       class="relative flex h-[75vh] flex-col items-center justify-end bg-army-900 sm:justify-center"
@@ -355,10 +355,13 @@ import BlurryImage from "../components/ui/BlurryImage.astro";
     margin-bottom: 1rem;
   }
 
-
   .header {
-    position:relative;
-    background: linear-gradient(60deg, rgba(84,58,183,1) 0%, rgba(0,172,193,1) 100%);
-    color:white;
+    position: relative;
+    background: linear-gradient(
+      60deg,
+      rgba(84, 58, 183, 1) 0%,
+      rgba(0, 172, 193, 1) 100%
+    );
+    color: white;
   }
 </style>

--- a/src/pages/landscaping.astro
+++ b/src/pages/landscaping.astro
@@ -4,9 +4,23 @@ import ButtonLink from "../components/ui/ButtonLink.astro";
 import Banner from "../components/ui/Banner.astro";
 import LandscapeImg from "../assets/landscape/general.webp";
 import BlurryImage from "../components/ui/BlurryImage.astro";
+import { service, breadcrumb, SITE_URL } from "../lib/business";
+
+const svc = service({
+  name: "Landscaping",
+  url: `${SITE_URL}/landscaping/`,
+  serviceType: "Landscaping",
+  description:
+    "Transform your desert landscape into a lush and inviting oasis with professional landscaping in Phoenix, AZ.",
+});
+
+const crumbs = breadcrumb([
+  { name: "Home", url: `${SITE_URL}/` },
+  { name: "Landscaping", url: `${SITE_URL}/landscaping/` },
+]);
 ---
 
-<Layout title="Landscaping">
+<Layout title="Landscaping" jsonLd={[svc, crumbs]}>
   <main>
     <section
       class="justify-top relative flex h-[75vh] flex-col items-center bg-army-900 sm:justify-center"
@@ -59,7 +73,9 @@ import BlurryImage from "../components/ui/BlurryImage.astro";
         </p>
         <ul class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
           <li class="rounded-lg border border-army-700 bg-army-800/50 p-6">
-            <h3 class="text-2xl font-bold pb-2 text-army-50">1. Bush Trimming</h3>
+            <h3 class="text-2xl font-bold pb-2 text-army-50">
+              1. Bush Trimming
+            </h3>
             <p class="text-lg text-army-200">
               We shape and maintain your bushes to keep them healthy, tidy, and
               visually appealing.
@@ -68,15 +84,17 @@ import BlurryImage from "../components/ui/BlurryImage.astro";
           <li class="rounded-lg border border-army-700 bg-army-800/50 p-6">
             <h3 class="text-2xl font-bold pb-2 text-army-50">2. Mowing</h3>
             <p class="text-lg text-army-200">
-              Our team provides clean, even lawn mowing to keep your grass at the
-              perfect height.
+              Our team provides clean, even lawn mowing to keep your grass at
+              the perfect height.
             </p>
           </li>
           <li class="rounded-lg border border-army-700 bg-army-800/50 p-6">
-            <h3 class="text-2xl font-bold pb-2 text-army-50">3. Edge Trimming</h3>
+            <h3 class="text-2xl font-bold pb-2 text-army-50">
+              3. Edge Trimming
+            </h3>
             <p class="text-lg text-army-200">
-              We trim along sidewalks, driveways, and flower beds for crisp, clean
-              lawn edges.
+              We trim along sidewalks, driveways, and flower beds for crisp,
+              clean lawn edges.
             </p>
           </li>
           <li class="rounded-lg border border-army-700 bg-army-800/50 p-6">
@@ -87,14 +105,18 @@ import BlurryImage from "../components/ui/BlurryImage.astro";
             </p>
           </li>
           <li class="rounded-lg border border-army-700 bg-army-800/50 p-6">
-            <h3 class="text-2xl font-bold pb-2 text-army-50">5. Irrigation Check</h3>
+            <h3 class="text-2xl font-bold pb-2 text-army-50">
+              5. Irrigation Check
+            </h3>
             <p class="text-lg text-army-200">
-              We inspect your sprinkler system to ensure it's running efficiently
-              and covering all zones.
+              We inspect your sprinkler system to ensure it's running
+              efficiently and covering all zones.
             </p>
           </li>
           <li class="rounded-lg border border-army-700 bg-army-800/50 p-6">
-            <h3 class="text-2xl font-bold pb-2 text-army-50">6. Debris Removal</h3>
+            <h3 class="text-2xl font-bold pb-2 text-army-50">
+              6. Debris Removal
+            </h3>
             <p class="text-lg text-army-200">
               We clear out branches, leaves, and other yard debris to keep your
               property neat and safe.
@@ -128,7 +150,9 @@ import BlurryImage from "../components/ui/BlurryImage.astro";
         </h4>
         <ul class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
           <li class="rounded-lg border border-army-700 bg-army-800/50 p-6">
-            <h3 class="text-2xl font-bold pb-2 text-army-50">1. Weed Prevention</h3>
+            <h3 class="text-2xl font-bold pb-2 text-army-50">
+              1. Weed Prevention
+            </h3>
             <p class="text-lg text-army-200">
               We apply treatments and strategies to stop weeds before they take
               root and spread in your yard.
@@ -142,17 +166,21 @@ import BlurryImage from "../components/ui/BlurryImage.astro";
             </p>
           </li>
           <li class="rounded-lg border border-army-700 bg-army-800/50 p-6">
-            <h3 class="text-2xl font-bold pb-2 text-army-50">3. Tree Trimming</h3>
+            <h3 class="text-2xl font-bold pb-2 text-army-50">
+              3. Tree Trimming
+            </h3>
             <p class="text-lg text-army-200">
-              Pruning and shaping of trees to improve appearance, promote healthy
-              growth, and prevent potential safety hazards.
+              Pruning and shaping of trees to improve appearance, promote
+              healthy growth, and prevent potential safety hazards.
             </p>
           </li>
           <li class="rounded-lg border border-army-700 bg-army-800/50 p-6">
-            <h3 class="text-2xl font-bold pb-2 text-army-50">4. Decorative Rock</h3>
+            <h3 class="text-2xl font-bold pb-2 text-army-50">
+              4. Decorative Rock
+            </h3>
             <p class="text-lg text-army-200">
-              Placement of aesthetically pleasing gravel or stone to enhance curb
-              appeal and reduce water usage in landscape design.
+              Placement of aesthetically pleasing gravel or stone to enhance
+              curb appeal and reduce water usage in landscape design.
             </p>
           </li>
           <li class="rounded-lg border border-army-700 bg-army-800/50 p-6">
@@ -170,14 +198,18 @@ import BlurryImage from "../components/ui/BlurryImage.astro";
             </p>
           </li>
           <li class="rounded-lg border border-army-700 bg-army-800/50 p-6">
-            <h3 class="text-2xl font-bold pb-2 text-army-50">7. Junk Removal</h3>
+            <h3 class="text-2xl font-bold pb-2 text-army-50">
+              7. Junk Removal
+            </h3>
             <p class="text-lg text-army-200">
-              Hauling away unwanted outdoor items, debris, or clutter to keep your
-              property clean and usable.
+              Hauling away unwanted outdoor items, debris, or clutter to keep
+              your property clean and usable.
             </p>
           </li>
           <li class="rounded-lg border border-army-700 bg-army-800/50 p-6">
-            <h3 class="text-2xl font-bold pb-2 text-army-50">8. Synthetic Grass</h3>
+            <h3 class="text-2xl font-bold pb-2 text-army-50">
+              8. Synthetic Grass
+            </h3>
             <p class="text-lg text-army-200">
               Professional installation of artificial turf that looks like real
               grass without the upkeep, watering, or mowing.
@@ -194,7 +226,9 @@ import BlurryImage from "../components/ui/BlurryImage.astro";
       </div>
     </section>
 
-    <section class="flex flex-wrap items-center justify-center gap-8 py-12 px-4">
+    <section
+      class="flex flex-wrap items-center justify-center gap-8 py-12 px-4"
+    >
       <img
         src="/landscape/pavers.webp"
         alt="Paver installation"

--- a/src/pages/pest-control/index.astro
+++ b/src/pages/pest-control/index.astro
@@ -5,6 +5,20 @@ import ButtonLink from "../../components/ui/ButtonLink.astro";
 import Banner from "../../components/ui/Banner.astro";
 import BlurryImage from "../../components/ui/BlurryImage.astro";
 import PestImage from "../../assets/general/truck.webp";
+import { service, breadcrumb, SITE_URL } from "../../lib/business";
+
+const svc = service({
+  name: "Pest Control",
+  url: `${SITE_URL}/pest-control/`,
+  serviceType: "Pest Control",
+  description:
+    "Comprehensive pest control in Phoenix, AZ — termites, scorpions, roaches, spiders, bed bugs, rodents, bees, and more.",
+});
+
+const crumbs = breadcrumb([
+  { name: "Home", url: `${SITE_URL}/` },
+  { name: "Pest Control", url: `${SITE_URL}/pest-control/` },
+]);
 
 type Pest = {
   name: string;
@@ -181,7 +195,7 @@ const reasons: Step[] = [
 // "When your home is built, contractors automatically make a giant hole that the pipes rarely fill. Insects take advantage of this gap so we treat all of your plumbing intrusions which is one of the most forgotten areas and is a highway for insects to come into your home.",
 ---
 
-<Layout title="Pest Control">
+<Layout title="Pest Control" jsonLd={[svc, crumbs]}>
   <main>
     <section
       class="justify-top relative flex h-[75vh] flex-col items-center bg-army-900 sm:justify-center"

--- a/src/pages/pools.astro
+++ b/src/pages/pools.astro
@@ -4,6 +4,20 @@ import ButtonLink from "../components/ui/ButtonLink.astro";
 import Banner from "../components/ui/Banner.astro";
 import PoolImg from "../assets/pool/18.webp";
 import BlurryImage from "../components/ui/BlurryImage.astro";
+import { service, breadcrumb, SITE_URL } from "../lib/business";
+
+const svc = service({
+  name: "Pool Services",
+  url: `${SITE_URL}/pools/`,
+  serviceType: "Pool Maintenance and Cleaning",
+  description:
+    "Professional pool cleaning, maintenance, and service in the Phoenix, AZ valley.",
+});
+
+const crumbs = breadcrumb([
+  { name: "Home", url: `${SITE_URL}/` },
+  { name: "Pools", url: `${SITE_URL}/pools/` },
+]);
 
 type Service = {
   name: string;
@@ -84,7 +98,7 @@ const servicesSorted = services.sort(({ name: a }, { name: b }) =>
               professionalism.
             </p>
  -->
-<Layout title="Pools">
+<Layout title="Pools" jsonLd={[svc, crumbs]}>
   <main>
     <section
       class="relative flex h-[75vh] flex-col items-center justify-end bg-army-900 sm:justify-center"
@@ -173,7 +187,9 @@ const servicesSorted = services.sort(({ name: a }, { name: b }) =>
           Your Plan for a<br />Well-Maintained Pool
         </h4>
         <ol class="grid grid-cols-1 gap-6 p-4 text-xl md:grid-cols-3">
-          <li class="flex max-w-[400px] flex-col gap-2 rounded-lg bg-army-50 p-8">
+          <li
+            class="flex max-w-[400px] flex-col gap-2 rounded-lg bg-army-50 p-8"
+          >
             <h3 class="text-2xl font-bold">Step 1</h3>
             <p>
               We'll assess your pool and give you a quote, as well as schedule a
@@ -181,7 +197,9 @@ const servicesSorted = services.sort(({ name: a }, { name: b }) =>
               kind of maintenance is needed.
             </p>
           </li>
-          <li class="flex max-w-[400px] flex-col gap-2 rounded-lg bg-army-50 p-8">
+          <li
+            class="flex max-w-[400px] flex-col gap-2 rounded-lg bg-army-50 p-8"
+          >
             <h3 class="text-2xl font-bold">Step 2</h3>
             <p>
               Our pool technicians will arrive to carry out the work. We'll
@@ -189,7 +207,9 @@ const servicesSorted = services.sort(({ name: a }, { name: b }) =>
               services are being performed and why they're needed.
             </p>
           </li>
-          <li class="flex max-w-[400px] flex-col gap-2 rounded-lg bg-army-50 p-8">
+          <li
+            class="flex max-w-[400px] flex-col gap-2 rounded-lg bg-army-50 p-8"
+          >
             <h3 class="text-2xl font-bold">Step 3</h3>
             <p>
               Relax and enjoy your pool! Schedule recurring maintenance to keep
@@ -248,7 +268,8 @@ const servicesSorted = services.sort(({ name: a }, { name: b }) =>
             Keeping your pool or spa clean and chemically balanced is essential
             for both safety and long-term savings. At Azteca Home Services, we
             take the guesswork out of pool care by protecting your family and
-            helping you avoid costly damage through proper, consistent treatment.
+            helping you avoid costly damage through proper, consistent
+            treatment.
           </p>
           <p class="text-xl mt-4">
             Choose AZTECA to do your weekly pool service, repairs, and more.


### PR DESCRIPTION
## Summary
- Shared `LocalBusiness` / `HomeAndConstructionBusiness` schema rendered on **every** page via `Layout.astro`
- Per-page additions on top of the site-wide business:
  - Home → `WebSite`
  - `/contact` → `ContactPage` + `BreadcrumbList`
  - `/landscaping`, `/pools`, `/pest-control` → `Service` + `BreadcrumbList`
  - All 16 pest sub-pages (via `Bug.astro`) → `Service` (with image, serviceType) + `BreadcrumbList`
- Schemas use `@graph` + `@id` cross-references so each page presents one connected entity graph (Service → provider → Business)
- New files: `src/lib/business.ts` (constants + `service()` / `breadcrumb()` helpers) and `src/components/JsonLd.astro` (renders `<script type="application/ld+json">` with `<` escaped to `<` to prevent script-tag breakout)

## Intentionally omitted
Hours and social URLs (`sameAs`, `openingHoursSpecification`). Better to skip than guess. Add to `src/lib/business.ts` when available.

## Test plan
- [x] `npm run build` succeeds, all 21 pages built
- [x] Verified rendered JSON-LD on home, `/pest-control/ants/`, and `/contact/` — each contains the expected `@graph` with cross-referenced `@id`s
- [ ] After deploy, paste `https://aztecahome.com/` and `https://aztecahome.com/pest-control/ants/` into [Google Rich Results Test](https://search.google.com/test/rich-results) — confirm 0 errors
- [ ] In Search Console under **Enhancements**, watch for new structured data reports (LocalBusiness, Breadcrumbs, etc.)