### PR TITLE
feat(seo): per-page meta, canonical URLs, OG and Twitter cards

### DIFF
--- a/src/layouts/Bug.astro
+++ b/src/layouts/Bug.astro
@@ -31,9 +31,17 @@ const crumbs = breadcrumb([
   { name: "Pest Control", url: `${SITE_URL}/pest-control/` },
   { name: frontmatter.bug, url: pageUrl },
 ]);
+
+const description = `Professional ${frontmatter.bug.toLowerCase()} control and mitigation in Phoenix, AZ from AZTECA Home Services. Schedule service today.`;
 ---
 
-<Layout title={frontmatter.title} jsonLd={[svc, crumbs]}>
+<Layout
+  title={`${frontmatter.title} — AZTECA Home Services`}
+  description={description}
+  ogImage={frontmatter.image}
+  ogType="article"
+  jsonLd={[svc, crumbs]}
+>
   <div class="container mx-auto mt-14">
     <div class="mx-4 flex items-center justify-between gap-4">
       <div class="rounded bg-army-100 p-4 font-bold">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,17 +2,37 @@
 import Footer from "../components/Footer.astro";
 import Header from "../components/Header.astro";
 import JsonLd from "../components/JsonLd.astro";
-import { business } from "../lib/business";
+import {
+  business,
+  SITE_URL,
+  SITE_NAME,
+  SITE_LOCALE,
+  DEFAULT_DESCRIPTION,
+  DEFAULT_OG_IMAGE,
+} from "../lib/business";
 // import { ViewTransitions } from "astro:transitions";
 
 export interface Props {
   title: string;
+  description?: string;
+  ogImage?: string;
+  ogType?: "website" | "article";
   jsonLd?: Record<string, unknown> | Record<string, unknown>[];
 }
 
-const { title, jsonLd } = Astro.props;
+const {
+  title,
+  description = DEFAULT_DESCRIPTION,
+  ogImage = DEFAULT_OG_IMAGE,
+  ogType = "website",
+  jsonLd,
+} = Astro.props;
+
 const extras = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
 const graph = [business, ...extras];
+
+const canonical = new URL(Astro.url.pathname, SITE_URL).href;
+const ogImageUrl = new URL(ogImage, SITE_URL).href;
 ---
 
 <!doctype html>
@@ -61,12 +81,24 @@ const graph = [business, ...extras];
       }
     </script>
 
-    <meta
-      name="Description"
-      content="Azteca Home Serives: Providing Pest Control, Pool, and Landscape services in the valley of Phoenix, AZ."
-    />
-    <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
+    <meta name="description" content={description} />
+    <link rel="canonical" href={canonical} />
+    <meta name="generator" content={Astro.generator} />
+
+    <meta property="og:site_name" content={SITE_NAME} />
+    <meta property="og:type" content={ogType} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonical} />
+    <meta property="og:image" content={ogImageUrl} />
+    <meta property="og:locale" content={SITE_LOCALE} />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImageUrl} />
+
     <JsonLd data={graph} />
     <!-- <ViewTransitions /> -->
   </head>

--- a/src/lib/business.ts
+++ b/src/lib/business.ts
@@ -1,4 +1,10 @@
 export const SITE_URL = "https://aztecahome.com";
+export const SITE_NAME = "AZTECA Home Services";
+export const SITE_LOCALE = "en_US";
+export const DEFAULT_DESCRIPTION =
+  "AZTECA Home Services: pest control, pool, and landscape services in the Phoenix, AZ valley. Call (602) 926-2021 for a free estimate.";
+export const DEFAULT_OG_IMAGE = "/general/truck.webp";
+
 export const BUSINESS_ID = `${SITE_URL}/#business`;
 export const WEBSITE_ID = `${SITE_URL}/#website`;
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -15,7 +15,11 @@ const crumbs = breadcrumb([
 ]);
 ---
 
-<Layout title="Contact Us" jsonLd={[contactPage, crumbs]}>
+<Layout
+  title="Contact AZTECA Home Services — Phoenix, AZ"
+  description="Get a free estimate for pest control, pool, or landscape service in Phoenix, AZ. Call (602) 926-2021 or reach out online."
+  jsonLd={[contactPage, crumbs]}
+>
   <main class="container my-12 mx-auto grid grid-cols-12">
     <section
       class="col-span-12 m-4 flex flex-col gap-4 bg-[url('/general/aztecaCalendarOutline.svg')] bg-contain bg-right-top bg-no-repeat text-xl sm:col-span-5"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,12 @@ import BlurryImage from "../components/ui/BlurryImage.astro";
 import { website } from "../lib/business";
 ---
 
-<Layout title="AZTECA Home Services" jsonLd={website}>
+<Layout
+  title="AZTECA Home Services — Pest Control, Pool & Landscape in Phoenix, AZ"
+  description="Family-run home services in the Phoenix valley: pest control, pool care, and landscaping. Free estimates — call (602) 926-2021."
+  ogImage="/landscape/general2.webp"
+  jsonLd={website}
+>
   <main>
     <section
       class="relative flex h-[75vh] flex-col items-center justify-end bg-army-900 sm:justify-center"

--- a/src/pages/landscaping.astro
+++ b/src/pages/landscaping.astro
@@ -20,7 +20,12 @@ const crumbs = breadcrumb([
 ]);
 ---
 
-<Layout title="Landscaping" jsonLd={[svc, crumbs]}>
+<Layout
+  title="Landscaping in Phoenix, AZ — AZTECA Home Services"
+  description="Trimming, cleanup, grass, pavers, and tree service. Transform your desert landscape into a lush oasis with AZTECA Home Services."
+  ogImage="/landscape/general.webp"
+  jsonLd={[svc, crumbs]}
+>
   <main>
     <section
       class="justify-top relative flex h-[75vh] flex-col items-center bg-army-900 sm:justify-center"

--- a/src/pages/pest-control/index.astro
+++ b/src/pages/pest-control/index.astro
@@ -195,7 +195,12 @@ const reasons: Step[] = [
 // "When your home is built, contractors automatically make a giant hole that the pipes rarely fill. Insects take advantage of this gap so we treat all of your plumbing intrusions which is one of the most forgotten areas and is a highway for insects to come into your home.",
 ---
 
-<Layout title="Pest Control" jsonLd={[svc, crumbs]}>
+<Layout
+  title="Pest Control in Phoenix, AZ — AZTECA Home Services"
+  description="Termites, scorpions, roaches, spiders, bed bugs, rodents, bees, and more. Comprehensive pest control across the Phoenix valley."
+  ogImage="/general/truck.webp"
+  jsonLd={[svc, crumbs]}
+>
   <main>
     <section
       class="justify-top relative flex h-[75vh] flex-col items-center bg-army-900 sm:justify-center"

--- a/src/pages/pools.astro
+++ b/src/pages/pools.astro
@@ -98,7 +98,12 @@ const servicesSorted = services.sort(({ name: a }, { name: b }) =>
               professionalism.
             </p>
  -->
-<Layout title="Pools" jsonLd={[svc, crumbs]}>
+<Layout
+  title="Pool Service in Phoenix, AZ — AZTECA Home Services"
+  description="Pool cleaning, maintenance, repair, and chemical service in the Phoenix valley. Keep your pool sparkling — call (602) 926-2021."
+  ogImage="/pool/maintenance.webp"
+  jsonLd={[svc, crumbs]}
+>
   <main>
     <section
       class="relative flex h-[75vh] flex-col items-center justify-end bg-army-900 sm:justify-center"


### PR DESCRIPTION
## Summary
- `Layout.astro` accepts `description`, `ogImage`, `ogType` props and renders a full SEO head: `<title>`, `<meta name="description">`, `<link rel="canonical">`, `og:*` (site_name, type, title, description, url, image, locale), and `twitter:*` (card, title, description, image)
- Removed the single site-wide hardcoded description (was misspelled "Serives" and identical on every page)
- Per-page metadata:
  - **Home** — landscape hero OG, family-run tagline
  - **/contact** — free-estimate-focused copy
  - **/landscaping**, **/pools**, **/pest-control** — section-specific OG image + copy
  - **All 16 pest sub-pages** (via `Bug.astro`) — bug-specific title suffix, description (`Professional <bug> control...`), `og:type="article"`, uses each bug's existing PNG as `og:image`
- New constants in `src/lib/business.ts`: `SITE_NAME`, `SITE_LOCALE`, `DEFAULT_DESCRIPTION`, `DEFAULT_OG_IMAGE`

## Future polish
Purpose-built 1200x630 OG cards per section would render better on Facebook/X. Existing hero images work but get center-cropped on those platforms (LinkedIn, iMessage, Slack handle them fine).

## Test plan
- [x] `npm run build` succeeds, all 21 pages built
- [x] Verified rendered head on home + `/pest-control/ants/` — title, description, canonical, og:*, twitter:* all present and per-page
- [ ] After deploy, preview-test:
  - https://www.opengraph.xyz/url/https%3A%2F%2Faztecahome.com%2F
  - Facebook Sharing Debugger: https://developers.facebook.com/tools/debug/
  - X Card validator (legacy): https://cards-dev.twitter.com/validator